### PR TITLE
Page::renderImage(): return a copyed image

### DIFF
--- a/libmupdf-qt/mupdf-page_p.h
+++ b/libmupdf-qt/mupdf-page_p.h
@@ -67,10 +67,4 @@ public:
 	int b, g, r, a; // background color
 };
 
-struct info_s
-{
-	fz_context *context;
-	fz_pixmap *pixmap;
-};
-
 #endif // end MUPDF_PAGE_P_H

--- a/mupdf-qt_example/test_page/main.cpp
+++ b/mupdf-qt_example/test_page/main.cpp
@@ -33,12 +33,9 @@ int main(int argc, char **argv)
 	qDebug() << page->size();
 
 	// test Page::renderImage()
-	{
-		// image should be deleted before document is deleted
-		QImage image = page->renderImage();
-		if (!image.save("a.png")) {
-			return 1;
-		}
+	QImage image = page->renderImage();
+	if (!image.save("a.png")) {
+		return 1;
 	}
 
 	delete page;


### PR DESCRIPTION
A copyed image can void memory management problems.
